### PR TITLE
Stage modifications

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -163,11 +163,11 @@ Kinetic.Stage.prototype = {
     },
     /**
      * Creates a composite data URL and passes it to a callback. If MIME type is not
-	 * specified, then "image/png" will result. For "image/jpeg", specify a quality
-	 * level as arg2 (range 0.0 - 1.0)
+     * specified, then "image/png" will result. For "image/jpeg", specify a quality
+     * level as arg2 (range 0.0 - 1.0)
      * @param {function} callback
-	 * @param {String} mimeType (optional)
-	 * @param {Number} arg2 (optional)
+     * @param {String} mimeType (optional)
+     * @param {Number} arg2 (optional)
      */
     toDataURL: function(callback, mimeType, arg2) {
         var bufferLayer = this.bufferLayer;
@@ -421,20 +421,20 @@ Kinetic.Stage.prototype = {
         // propapgate backwards through children
         for(var i = children.length - 1; i >= 0; i--) {
             var child = children[i];
-			if (child.isListening) {
-				if(child.className === 'Shape') {
-					var exit = this._detectEvent(child, evt);
-					if(exit) {
-						return true;
-					}
-				}
-				else {
-					var exit = this._traverseChildren(child, evt);
-					if(exit) {
-						return true;
-					}
-				}
-			}
+            if (child.isListening) {
+                if(child.className === 'Shape') {
+                    var exit = this._detectEvent(child, evt);
+                    if(exit) {
+                        return true;
+                    }
+                }
+                else {
+                    var exit = this._traverseChildren(child, evt);
+                    if(exit) {
+                        return true;
+                    }
+                }
+            }
         }
 
         return false;


### PR DESCRIPTION
- Added check for child.isListening in _traverseChildren() to handle case when a node overlaps another and you don't want to handle events for the topmost node.
- Added support for event.offsetX/offsetY in _setMousePosition to work around a Kinetic bug observed in Windows 8/Internet Explorer 10
- Added MIME type support to toDataURL() so that additional image formats can be generated in accordance to the spec
