### PR TITLE
Workaround for older browser security exception using toDataURL() with parameters

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -161,7 +161,15 @@ Kinetic.Stage.prototype = {
                     addLayer(n);
                 }
                 else {
-                    callback(bufferLayer.getCanvas().toDataURL(mimeType, quality));
+                    try {
+                        // If this call fails (due to browser bug, like in Firefox 3.6),
+                        // then revert to previous no-parameter image/png behavior
+                        callback(bufferLayer.getCanvas().toDataURL(mimeType, quality));
+                    }
+                    catch(exception)
+                    {
+                        callback(bufferLayer.getCanvas().toDataURL());
+                    }
                 }
             };
             imageObj.src = dataURL;


### PR DESCRIPTION
Revert to previous no-parameter (image/png) behavior if an exception is
encountered while calling canvas toDataURL() with parameters.  See this
forum post: http://www.kineticjs.com/forum/viewtopic.php?f=10&t=423
