### PR TITLE
Adding the maxWidth property to the Text Shape

### DIFF
--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -18,7 +18,8 @@ Kinetic.Text = function(config) {
         align: 'left',
         verticalAlign: 'top',
         padding: 0,
-        fontStyle: 'normal'
+        fontStyle: 'normal',
+        maxWidth: undefined
     });
 
     this.shapeType = "Text";
@@ -65,7 +66,13 @@ Kinetic.Text = function(config) {
         // draw text
         if(this.attrs.textFill !== undefined) {
             context.fillStyle = this.attrs.textFill;
-            context.fillText(this.attrs.text, tx, ty);
+
+            if (this.attrs.maxWidth !== undefined) {
+                context.fillText(this.attrs.text, tx, ty, this.attrs.maxWidth);
+            }
+            else {
+                context.fillText(this.attrs.text, tx, ty);
+            }
         }
         if(this.attrs.textStroke !== undefined || this.attrs.textStrokeWidth !== undefined) {
             // defaults
@@ -77,7 +84,13 @@ Kinetic.Text = function(config) {
             }
             context.lineWidth = this.attrs.textStrokeWidth;
             context.strokeStyle = this.attrs.textStroke;
-            context.strokeText(this.attrs.text, tx, ty);
+
+            if (this.attrs.maxWidth !== undefined) {
+                context.strokeText(this.attrs.text, tx, ty, this.attrs.maxWidth);
+            }
+            else {
+                context.strokeText(this.attrs.text, tx, ty);
+            }
         }
     };
     // call super constructor
@@ -242,6 +255,19 @@ Kinetic.Text.prototype = {
             width: metrics.width,
             height: parseInt(this.attrs.fontSize, 10)
         };
+    },
+    /**
+     * get max width in pixels
+     */
+    getMaxWidth: function() {
+        return this.attrs.maxWidth;
+    },
+    /**
+     * set max width
+     * @param {float} max width
+     */
+    setMaxWidth: function(maxWidth) {
+        this.attrs.maxWidth = maxWidth;
     }
 };
 // extend Shape


### PR DESCRIPTION
Thus we can use the last (and optional) arguments of fillText() and strokeText as described in https://developer.mozilla.org/en/Drawing_text_using_a_canvas#fillText() and https://developer.mozilla.org/en/Drawing_text_using_a_canvas#strokeText()
