### PR TITLE
Allow users to stop the default action to preventDefault() on a touch event

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -654,20 +654,29 @@ Kinetic.Stage.prototype = {
         }, false);
         // mobile events
         this.content.addEventListener('touchstart', function(evt) {
-            evt.preventDefault();
+			evt.cancelBubble = true;
             that.touchStart = true;
             that._handleStageEvent(evt);
+			if (evt.cancelBubble) {
+				evt.preventDefault();
+			}
         }, false);
 
         this.content.addEventListener('touchmove', function(evt) {
-            evt.preventDefault();
+            evt.cancelBubble = true;
             that._handleStageEvent(evt);
+			if (evt.cancelBubble) {
+				evt.preventDefault();
+			}
         }, false);
 
         this.content.addEventListener('touchend', function(evt) {
-            evt.preventDefault();
+            evt.cancelBubble = true;
             that.touchEnd = true;
             that._handleStageEvent(evt);
+			if (evt.cancelBubble) {
+				evt.preventDefault();
+			}
         }, false);
     },
     /**


### PR DESCRIPTION
Hi,

There was a thread (be it short) that was wanting to know how to allow touch events to pass through to the browser. At those times, one could set the cancelBubble to false on the event and the mobile browser would receive it. I added the code to handle that in stage.js/_listen

Gerard
