### PR TITLE
Call setSize when height/width updated on a Stage using setAttrs.

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -222,6 +222,16 @@ Kinetic.Node.prototype = {
                                 go._setAttr(obj[key], 'width', size.width);
                                 go._setAttr(obj[key], 'height', size.height);
                                 break;
+                            case 'height':
+                                if (that.nodeType == 'Stage' && that.content) {
+                                    that.setSize(that.attrs['width'], val);
+                                    break;
+                                }
+                            case 'width':
+                                if (that.nodeType == 'Stage' && that.content) {
+                                    that.setSize(val, that.attrs['height']);
+                                    break;
+                                }                                
                             default:
                                 obj[key] = c[key];
                                 break;


### PR DESCRIPTION
Calling setAttrs on a Stage to try and update the height or width does not have the same effect as calling setSize; the attributes are not cascaded down to the layers and the layers are not redrawn. This patch updates setAttrs to invoke setSize when required.
