### PR TITLE
Calling stage.toJSON() prevents subsequent drawing on existing child layers

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -163,17 +163,15 @@ Kinetic.Stage.prototype = {
         function addNode(node) {
             var obj = {};
 
-            var cleanAttrs = node.attrs;
+            obj.attrs = {};
 
-            // remove function, image, DOM, and objects with methods
-            for(var key in cleanAttrs) {
-                var val = cleanAttrs[key];
-                if(go._isFunction(val) || go._isElement(val) || go._hasMethods(val)) {
-                    cleanAttrs[key] = undefined;
+            // serialize only attributes that are not function, image, DOM, or objects with methods
+            for(var key in node.attrs) {
+                var val = node.attrs[key];
+                if(!go._isFunction(val) && !go._isElement(val) && !go._hasMethods(val)) {
+                    obj.attrs[key] = val;
                 }
             }
-
-            obj.attrs = cleanAttrs;
 
             obj.nodeType = node.nodeType;
             obj.shapeType = node.shapeType;


### PR DESCRIPTION
The bug re-producing code is here:

http://jsfiddle.net/BGkBq/

There should be 3 lines, but as you can see, only one is drawn.

If you call stage.toJSON(), you cannot subsequently draw() on child layers.

I tracked the bug down to the way attributes are being "copied" from the original node objects to the serialized objects. The problem is that the `var cleanAttrs` is an object reference to `node.attrs` and setting `cleanAttrs[key] = undefined`, actually alters the original `node.attrs[key]` value

My pull request changes the approach by selectively including instead of excluding attributes. This avoids the (presumably) unintended, bug-causing side effects.

Please let me know if you have any questions.

Fantastic work on the library, btw. The API is a joy to use.
