### PR TITLE
Direct-src support and autoloading in Kinetic.Image

### DIFF
--- a/src/shapes/Image.js
+++ b/src/shapes/Image.js
@@ -78,7 +78,6 @@ Kinetic.Image = Kinetic.Shape.extend({
             };
             
             this.attrs.image.src = src;
-            return;
         }
         
         this._checkReady(); // begin to check if the image is ready to draw
@@ -90,8 +89,10 @@ Kinetic.Image = Kinetic.Shape.extend({
         if(!!this.attrs.image) {
             if(this.attrs.image.complete) {
                 this.ready = true;
-                this.getLayer().draw();
-                return;
+                
+				if(this.getParent() !== undefined) { // redraw image if it has a parent
+					this.getLayer().draw();
+				}
             } else {
                 this.ready = false;
                 setTimeout(this._checkReady, 1000); // check again in 1s


### PR DESCRIPTION
It's often usefull to let the library load images idependently. Since you need one Kinetic.Image object per Image you want to draw, why don't load images into the constructor ?

You can now pass your Image objects, don't worry about loading, Kinetic will check if the Image has loaded, if not, he will wait for that and then draw the Image node.

For convenience, I've also added a support for direct-src input, so you can pass in image attr the path to the image you want to draw.
