### PR TITLE
Miscalculation of container position

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -781,17 +781,13 @@ Kinetic.Stage = Kinetic.Container.extend({
      * get container position
      */
     _getContentPosition: function() {
-        var obj = this.content;
-        var top = 0;
-        var left = 0;
-        while(obj && obj.tagName !== 'BODY') {
-            top += obj.offsetTop - obj.scrollTop;
-            left += obj.offsetLeft - obj.scrollLeft;
-            obj = obj.offsetParent;
-        }
+        var
+            rect = this.content.getBoundingClientRect(),
+            root = document.documentElement
+        ;
         return {
-            top: top,
-            left: left
+            top: rect.top + root.scrollTop,
+            left: rect.left + root.scrollLeft
         };
     },
     /**


### PR DESCRIPTION
Due to a wrong calculation of offsetTop and offsetLeft by the browsers, the position of the container is miscalculated if it is positioned and have a border.

You can found a test case here: http://jsfiddle.net/q5t4s/
Fail under Firefox 15, Chrome 20, IE9. Ok under Opera 12.

This patch should fix this by using getBoundingClientRect() instead of offsetTop and offsetLeft.
