### PR TITLE
Fix getStrokeColor -> getStroke in Shape docs.

### DIFF
--- a/src/Shape.js
+++ b/src/Shape.js
@@ -399,7 +399,7 @@ Kinetic.Node.addGettersSetters(Kinetic.Shape, ['fill', 'stroke', 'lineJoin', 'st
 
 /**
  * get stroke color
- * @name getStrokeColor
+ * @name getStroke
  * @methodOf Kinetic.Shape.prototype
  */
 


### PR DESCRIPTION
Minor issue in the docs for Shape. `getStrokeColor` is actually implemented as `getStroke`. Unless I missed something, the document generation isn't part of the repo and is something you'll need to do on your end? If I did miss something, I'd be glad to update that as well. Cheers.
