### PR TITLE
Mouswheel event support

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -428,7 +428,7 @@ Kinetic.Stage.prototype = {
     _bindContentEvents: function() {
         var go = Kinetic.Global;
         var that = this;
-        var events = ['mousedown', 'mousemove', 'mouseup', 'mouseout', 'touchstart', 'touchmove', 'touchend'];
+        var events = ['mousedown', 'mousemove', 'mouseup', 'mouseout', 'mousewheel', 'touchstart', 'touchmove', 'touchend'];
 
         for(var n = 0; n < events.length; n++) {
             var pubEvent = events[n];
@@ -533,6 +533,15 @@ Kinetic.Stage.prototype = {
 
         // end drag and drop
         this._endDrag(evt);
+    },
+    _mousewheel: function (evt) {
+        this._setUserPosition(evt);
+        var shapes = this.get('Shape');
+        for (var i = 0; i < shapes.length; i++) {
+            if (shapes[i].eventListeners['mousewheel'] != null && shapes[i].intersects(this.getUserPosition())) {
+                shapes[i]._handleEvent('mousewheel', evt);
+            }
+        }
     },
     _touchstart: function(evt) {
         this._setUserPosition(evt);


### PR DESCRIPTION
I have tried to implement it using "getIntersections",
but it was incredibly slow (1-2 seconds reaction. stage with 1 layer, 1 group, 1 rectangle and 18 images)

Warning, in this realization, layer levels are ignored.
It is required because if you are listening for events on one shape,
and there is other shapes on top of it - event will not find the correct shape.
Example: group with rectangle as background and with many small shapes/groups which are on top of background by level.
