### PR TITLE
Added offsetX/offsetY back into _setMousePosition

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -515,8 +515,8 @@ Kinetic.Stage.prototype = {
      * @param {Event} evt
      */
     _setMousePosition: function(evt) {
-        var mouseX = evt.clientX - this._getContentPosition().left;
-        var mouseY = evt.clientY - this._getContentPosition().top;
+        var mouseX = evt.offsetX || (evt.clientX - this._getContentPosition().left);
+        var mouseY = evt.offsetY || (evt.clientY - this._getContentPosition().top);
         this.mousePos = {
             x: mouseX,
             y: mouseY


### PR DESCRIPTION
My case may be related to using css3 3D transform on the DIV that 
holds the stage, but without offsetX/Y, IE10 is not correctly determining 
where clicks are happening.  
