### PR TITLE
Fixed issue where filter would resize Image

### DIFF
--- a/src/shapes/Image.js
+++ b/src/shapes/Image.js
@@ -75,7 +75,7 @@ Kinetic.Image.prototype = {
     applyFilter: function(config) {
         var canvas = new Kinetic.Canvas(this.attrs.width, this.attrs.height);
         var context = canvas.getContext();
-        context.drawImage(this.attrs.image, 0, 0);
+        context.drawImage(this.attrs.image, 0, 0, this.attrs.width, this.attrs.height);
         try {
             var imageData = context.getImageData(0, 0, canvas.getWidth(), canvas.getHeight());
             config.filter(imageData, config.config);


### PR DESCRIPTION
Updated applyFilter to use the size of the Image shape instead of the size of the source image.

This prevents the image from resizing when applying a filter to an Kinetic.Image that was created with an ImageObject of a different size than the Kinetic.Image.
