### PR TITLE
Lines with rounded corners

### DIFF
--- a/src/shapes/Line.js
+++ b/src/shapes/Line.js
@@ -115,11 +115,19 @@ Kinetic.Line.prototype = {
                     // Reduce the radius if there is not enough space
                     radius = Math.min(radius, Math.min(lastlen, nextlen) * Math.tan(halfangle))
 
-                    // distance from x,y to center of the arc
-                    var arcdist = radius/Math.sin(halfangle)
-                    var arcX = x + arcdist*Math.sin(normangle)
-                    var arcY = y + arcdist*Math.cos(normangle)
-                    context.arc(arcX, arcY, radius, startangle, endangle, !clockwise);
+                    if (radius <= 0) {
+                        // special case: the line segments make a 180° turn
+                        var arcdist = Math.min(lastlen, nextlen)
+                        var arcX = x + arcdist*Math.sin(normangle)
+                        var arcY = y + arcdist*Math.cos(normangle)
+                        context.lineTo(arcX, arcY);
+                    } else {
+                        // distance from x,y to center of the arc
+                        var arcdist = radius/Math.sin(halfangle)
+                        var arcX = x + arcdist*Math.sin(normangle)
+                        var arcY = y + arcdist*Math.cos(normangle)
+                        context.arc(arcX, arcY, radius, startangle, endangle, !clockwise);
+                    }
                 }
             }
             else {


### PR DESCRIPTION
So far only rects could have rounded corners. It would be great if lines could also have rounded corners.

Please discuss this patch before merging the code.

This patch is very simple (only two lines) and effective for most scenarios. However, it has three disadvantages:
1. It uses arcTo() which is tagged as "problematic in Opera" elsewhere in this library.
2. it does not yet correct for very acute angles, where the radius must be decreased for the rounding to fit.
3. It is not possible to combine dashed lines with rounded corners

I'm willing to write code that resolves the first two issues, but be aware that this is computationally intensive, so I like some feedback if you are willing to merge such a patch before writing it. As for the third item, I'm sure I can write the code to support both rounded corners and dashes lines, but that really is a mayor effort.

Currently, I'm only interested in rounded corners for lines, and am willing to write that code. Do you want support for other type of shapes too, and if so -- which shapes would you consider?

(edit: not to self: don't mix MediaWiki and Markdown markup languages...)
