### PR TITLE
Correct error when trying to get dataURL from Stage without layers

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -189,9 +189,18 @@ Kinetic.Stage.prototype = {
         var layers = this.children;
 
         function drawLayer(n) {
-            var layer = layers[n];
-            var layerUrl = layer.toDataURL();
-            var imageObj = new Image();
+            var layer;
+            var layerUrl;
+            var imageObj;
+
+            if(layers.length < 1) {
+                return;
+            }
+
+            layer = layers[n];
+            layerUrl = layer.toDataURL();
+            imageObj = new Image();
+
             imageObj.onload = function() {
                 context.drawImage(imageObj, 0, 0);
 

--- a/tests/js/unit/stageTests.js
+++ b/tests/js/unit/stageTests.js
@@ -259,5 +259,31 @@ Test.Modules.STAGE = {
         test(stage.getStage() !== undefined, 'stage is undefined');
 
         //console.log(stage.getStage());
+    },
+    'test stage don\'t throw error if has no layers and try to get dataURL': function(containerId) {
+        var stage = new Kinetic.Stage({
+            container: containerId,
+            width: 578,
+            height: 200
+        });
+
+        try {
+
+            stage.toDataURL({
+                callback: function(data){
+                    test(false, "'callback' called even when there was no layer to draw");
+                },
+                mimeType: 'image/jpeg',
+                quality: 0.95
+            });
+
+            test(true, "method 'toDataURL' didn't throw an error when no layers were present");
+
+        } catch(e) {
+
+            test(false, "method 'toDataURL' throwed an error when no layers were present");
+
+        }
+
     }
 };


### PR DESCRIPTION
If you try to get the dataUrl from a stage whithout layers, the javascript engine will throw a `TypeError` exception.

``` javascript
var stage = new Kinetic.Stage({
    container: containerId,
    width: 578,
    height: 200
});

// TypeError
stage.toDataURL({
    callback: function(data){  },
    mimeType: 'image/png'
});
```

To fix this issue I just added a check to see if there was any layer on the stage. If there isn't any, then just return nothing (stop execution).
