### PR TITLE
Fix for Text at (0,0) rendering offscreen with certain fonts

### DIFF
--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -52,11 +52,10 @@
             var textArr = this.textArr;
 
             context.font = this.attrs.fontStyle + ' ' + this.attrs.fontSize + 'pt ' + this.attrs.fontFamily;
-            context.textBaseline = 'middle';
+            context.textBaseline = 'top';
             context.textAlign = 'left';
             context.save();
-            context.translate(p, 0);
-            context.translate(0, p + this.getTextHeight() / 2);
+            context.translate(p, p);
 
             // draw text lines
             for(var n = 0; n < textArr.length; n++) {


### PR DESCRIPTION
To see the bug in action: visit the `Text` tutorial at http://www.html5canvastutorials.com/kineticjs/html5-canvas-kineticjs-text-tutorial/

...and replace the definition of simpleText with:

```
  var simpleText = new Kinetic.Text({
    x: 0,
    y: 0,
    text: 'Simple Text',
    fontSize: 10,
    fontFamily: 'Arial',
    textFill: 'green'
  });
```

Note that despite being specified at {x: 0, y: 0}, the text is being rendered outside the viewable area.

This only happens with certain fonts (change it from Arial to Calibri and it will look fine, and Times and it will look closer), and it seems to be related to the "always draw text with `textBaseline middle`, then add `this.getTextHeight() / 2`" logic. That calculation is off by a few pixels for certain fonts.

Changing it to simply use `textBaseline "top"` and not adding `getTextHeight() / 2` fixes the issue.
