### PR TITLE
Sprites not respecting width and height

### DIFF
--- a/src/shapes/Sprite.js
+++ b/src/shapes/Sprite.js
@@ -32,6 +32,8 @@
             var anim = this.attrs.animation;
             var index = this.attrs.index;
             var f = this.attrs.animations[anim][index];
+            var width = this.attrs.width || f.width;
+            var height = this.attrs.height || f.height;
 
             if(this.attrs.image) {
 
@@ -39,16 +41,18 @@
                 context.rect(0, 0, f.width, f.height);
                 context.closePath();
 
-                this.drawImage(context, this.attrs.image, f.x, f.y, f.width, f.height, 0, 0, f.width, f.height);
+                this.drawImage(context, this.attrs.image, f.x, f.y, f.width, f.height, 0, 0, width, height);
             }
         },
         drawHitFunc: function(context) {
             var anim = this.attrs.animation;
             var index = this.attrs.index;
             var f = this.attrs.animations[anim][index];
-
+            var width = this.attrs.width || f.width;
+            var height = this.attrs.height || f.height;
+            
             context.beginPath();
-            context.rect(0, 0, f.width, f.height);
+            context.rect(0, 0, width, height);
             context.closePath();
             this.fillStroke(context);
         },


### PR DESCRIPTION
Sprites were not scaling to their width and height in the same way as Images so I've created this small pull request as a fix. If a width or height has not been set then the native size of the frame is used as before.
