### PR TITLE
Added compatibility with Brunch's command-line tests.

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -8,6 +8,7 @@
     Kinetic.Canvas = function(width, height) {
         this.element = document.createElement('canvas');
         this.context = this.element.getContext('2d');
+        this.element.style = this.element.style || {};
 
         // set dimensions
         this.element.width = width || 0;


### PR DESCRIPTION
Although the `nodejs` branch provides standalone NodeJS test functionality, evidently all that's needed to get them working with Brunch (http://brunch.io) tests is to give canvasses a default style object. (And having `jsdom` and `canvas` installed, of course.)

Without this, trying to run Brunch tests involving Kinetic fail because Layer tries to set `this.canvas.getElement().style.position = 'absolute'` and evidently jsdom's implementation of canvas does not give it a default `style` object.

With this change, the style object is guaranteed to exist, and Brunch tests work.
