### PR TITLE
Multi touch fails if no normal touch have happend before

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -530,7 +530,7 @@
          * @param {Event} evt
          */
         _setTouchPosition: function(evt) {
-            if(evt.touches !== undefined && evt.touches.length === 1) {
+            if(evt.touches !== undefined && (evt.touches.length === 1 || this.touchPos === undefined)) {
                 // one finger
                 var touch = evt.touches[0];
                 // Get the information for finger #1


### PR DESCRIPTION
Multi touch fails with:
NOT_SUPPORTED_ERR: DOM Exception 9: The implementation did not support the requested type of object or operation.

because of pos being `{x: NaN, y: NaN}`  at
`var p = layer.hitCanvas.context.getImageData(Math.round(pos.x), Math.round(pos.y), 1, 1).data;``
in``getIntersection(pos)```

Setting stage defaults to the following solves that problem.

```
   /**
     * set defaults
     */
    _setStageDefaultProperties: function() {
        this.nodeType = 'Stage';
        this.dblClickWindow = 400;
        this.targetShape = null;
        this.mousePos = {
            x: 0,
            y: 0
        };
        this.clickStart = false;
        this.touchPos = {
            x: 0,
            y: 0
        };
        this.tapStart = false;

        /*
         * ids and names hash needs to be stored at the stage level to prevent
         * id and name collisions between multiple stages in the document
         */
        this.ids = {};
        this.names = {};
    }
```
