### PR TITLE
the correct call event handlers

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -971,7 +971,7 @@
             }
         },
         _executeHandlers: function(eventType, evt) {
-            var events = this.eventListeners[eventType];
+            var events = this.eventListeners[eventType].slice(0);
             var len = events.length;
             for(var i = 0; i < len; i++) {
                 events[i].handler.apply(this, [evt]);


### PR DESCRIPTION
When run the handler, array of events may change.
For example when event for object you need to call an once.

``` javascript
node.on('upadate.1', funciton() {
    node.off('upadate.1');
});
```
