### PR TITLE
Update src/Transition.js - transition complete callback needs the node

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -56,7 +56,7 @@
             node.transAnim.stop();
             node.setAttrs(newAttrs);
             if(config.callback) {
-                config.callback();
+                config.callback(node);
             }
         };
     };


### PR DESCRIPTION
Transition now passes to the callback function the node the transition was running on.

If you have multiple transitions running in parallel, you often need to know the Node that the transition was running on when the transition completes, so that you can perform cleanup, etc on that Node.
