### PR TITLE
Added support for mixing WebGL context inside a layer.

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -11,7 +11,7 @@
      * @param {Number} width
      * @param {Number} height
      */
-    Kinetic.Canvas = function(width, height, pixelRatio) {
+    Kinetic.Canvas = function(width, height, pixelRatio, contextId) {
         this.pixelRatio = pixelRatio || _pixelRatio;
         this.width = width;
         this.height = height;
@@ -20,7 +20,8 @@
         this.element.style.margin = 0;
         this.element.style.border = 0;
         this.element.style.background = 'transparent';
-        this.context = this.element.getContext('2d');
+        if(typeof (contextId) != "string") contextId = '2d';
+        this.context = this.element.getContext(contextId);
         this.setSize(width || 0, height || 0);
     };
 
@@ -216,8 +217,8 @@
         }
     };
 
-    Kinetic.SceneCanvas = function(width, height, pixelRatio) {
-        Kinetic.Canvas.call(this, width, height, pixelRatio);
+    Kinetic.SceneCanvas = function(width, height, pixelRatio, contextId) {
+        Kinetic.Canvas.call(this, width, height, pixelRatio, contextId);
     };
 
     Kinetic.SceneCanvas.prototype = {
@@ -394,4 +395,27 @@
         }
     };
     Kinetic.Global.extend(Kinetic.HitCanvas, Kinetic.Canvas);
+
+    Kinetic.WebGLCanvas = function(width, height, pixelRatio) {
+        Kinetic.SceneCanvas.call(this, width, height, pixelRatio, 'experimental-webgl');
+    };
+
+    Kinetic.WebGLCanvas.prototype = {
+        /**
+         * does nothing, do not remove
+         * @name clear
+         * @methodOf Kinetic.WebGLCanvas.prototype
+         */
+        clear: function() { },
+        setWidth: function(width) {
+            var pixelRatio = this.pixelRatio;
+            Kinetic.Canvas.prototype.setWidth.call(this, width);
+        },
+        setHeight: function(height) {
+            var pixelRatio = this.pixelRatio;
+            Kinetic.Canvas.prototype.setHeight.call(this, height);
+        },
+    };
+
+    Kinetic.Global.extend(Kinetic.WebGLCanvas, Kinetic.SceneCanvas);
 })();

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -23,7 +23,10 @@
             this.nodeType = 'Layer';
             this.beforeDrawFunc = undefined;
             this.afterDrawFunc = undefined;
-            this.canvas = new Kinetic.SceneCanvas();
+            if (config != null && config.canvas != null)
+                this.canvas = config.canvas;
+            else
+                this.canvas = new Kinetic.SceneCanvas();
             this.canvas.getElement().style.position = 'absolute';
             this.hitCanvas = new Kinetic.HitCanvas();
 


### PR DESCRIPTION
Canvas uses 2d context by default, it doesn't allow for optional
configuration. This creates conflicts with WebGL (e.g. with three.js
library).

For this to happen, an additional configuration parameter was necessary for both Kinetic.Canvas and for Kinetic.Layer. In the former case, a constant string was replaced, and in the latter case you can supply your own "canvas" (a class inheriting Kinetic.Canvas).
