### PR TITLE
_getRandomColor should use floor, not round

### DIFF
--- a/src/util/Type.js
+++ b/src/util/Type.js
@@ -280,9 +280,9 @@
             };
         },
         _getRandomColorKey: function() {
-            var r = Math.round(Math.random() * 255);
-            var g = Math.round(Math.random() * 255);
-            var b = Math.round(Math.random() * 255);
+            var r = Math.floor(Math.random() * 256);
+            var g = Math.floor(Math.random() * 256);
+            var b = Math.floor(Math.random() * 256);
             return this._rgbToHex(r, g, b);
         },
         // o1 takes precedence over o2


### PR DESCRIPTION
With .round the function returns 0 and 255 with a 50% smaller
probability than ony of the numbers from 1 to 254. Instead, [0, 1) from
Math.random \* 256 becomes [0, 256) then floored becomes 0, 1, ... 255
uniformly distributed.
