### PR TITLE
Some lines that speed up event handling (20 to 18 % time spent) and make code cleaner.

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -306,15 +306,10 @@
             var that = this;
             var events = ['mousedown', 'mousemove', 'mouseup', 'mouseout', 'touchstart', 'touchmove', 'touchend'];
 
-            for(var n = 0; n < events.length; n++) {
-                var pubEvent = events[n];
-                // induce scope
-                ( function() {
-                    var event = pubEvent;
-                    that.content.addEventListener(event, function(evt) {
-                        that['_' + event](evt);
-                    }, false);
-                }());
+            for (var n = 0; n < events.length; n++) {
+              var pubEvent = events[n];
+              var f = that['_' + pubEvent];
+              that.content.addEventListener(pubEvent, f.bind(that), false);
             }
         },
         _mouseout: function(evt) {


### PR DESCRIPTION
The event handler function was fetched upon every fired event. This is
now avoided by fetching the function once before adding the listener.
This is partly a refactoring but also changes the code, since changes of
the events in that[] are now considered only during the call of
_bindContentEvents. If an event is removed between event firings however, the previous code
would crash anyway, since 

that['_' + event] 

would then be null. So I believe it is save not to evaluate that[] upon every fired event.

Performance profiling showed slight advantage, from 20% spent to 18% spent inside
event handler. And the code is cleaner.
