### PR TITLE
Fix incorrect casing in Thorfile

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -150,7 +150,7 @@ class Build < Thor
       content.gsub!("{{version}}", version)
       content.sub!("{{date}}", date)
       content.gsub!("{{NodeParams}}", IO.read("configParams/NodeParams.txt"))
-      content.gsub!("{{ContainerParams}}", IO.read("configParams/ContainerParams.txt"))
+      content.gsub!("{{ContainerParams}}", IO.read("configParams/containerParams.txt"))
       content.gsub!("{{ShapeParams}}", IO.read("configParams/ShapeParams.txt"))
       
       return content


### PR DESCRIPTION
The file "configParams/ContainerParams.txt" is actually "configParams/containerParams.txt". This breaks build on case-sensitive filesystem.
