### PR TITLE
Adds skew transformation support.

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -650,6 +650,9 @@
                 x = this.getX(), 
                 y = this.getY(), 
                 rotation = this.getRotation(),
+                skew = this.getSkew(), 
+                skewX = skew.x,
+                skewY = skew.y,
                 scale = this.getScale(), 
                 scaleX = scale.x, 
                 scaleY = scale.y, 
@@ -669,7 +672,9 @@
             if(offsetX !== 0 || offsetY !== 0) {
                 m.translate(-1 * offsetX, -1 * offsetY);
             }
-             
+            if(skewX !== 0 || skewY !== 0) {
+                m.skew(skewX, skewY);
+            }            
             // cache result
             this.cachedTransform = m;
             return m;
@@ -849,12 +854,17 @@
             }
         },
         _clearTransform: function() {
-            var scale = this.getScale(), 
+            var scale = this.getScale(),
               offset = this.getOffset(),
+              skew = this.getSkew(),
               trans = {
                   x: this.getX(),
                   y: this.getY(),
                   rotation: this.getRotation(),
+                  skew: {
+                      x: skew.x,
+                      y: skew.y
+                  },
                   scale: {
                       x: scale.x,
                       y: scale.y
@@ -868,6 +878,10 @@
             this.attrs.x = 0;
             this.attrs.y = 0;
             this.attrs.rotation = 0;
+            this.attrs.skew = {
+                x: 0,
+                y: 0
+            };
             this.attrs.scale = {
                 x: 1,
                 y: 1
@@ -1019,6 +1033,11 @@
         this.addRotationGetter(constructor, arr, def);
         this.addRotationSetter(constructor, arr, isTransform);    
     };
+    Kinetic.Node.addSkewGetterSetter = function(constructor, arr, def, isTransform) {
+        this.addSkewGetter(constructor, arr, def);
+        this.addSkewSetter(constructor, arr, isTransform);    
+    };
+    
     Kinetic.Node.addSetter = function(constructor, attr, isTransform) {
         var that = this,
             method = SET + Kinetic.Type._capitalize(attr);
@@ -1074,6 +1093,25 @@
             }
         };
     };
+    Kinetic.Node.addSkewSetter = function(constructor, attr, isTransform) {
+        var that = this,
+            method = SET + Kinetic.Type._capitalize(attr);
+            
+        // radians
+        constructor.prototype[method] = function(val) {
+            this.setAttr(attr, val);
+            if (isTransform) {
+                this.cachedTransform = null;
+            }
+        };
+        // degrees
+        constructor.prototype[method + DEG] = function(deg) {
+            this.setAttr(attr, Kinetic.Type._degToRad(deg));
+            if (isTransform) {
+                this.cachedTransform = null;
+            }
+        };
+    };
     Kinetic.Node.addGetter = function(constructor, attr, def) {
         var that = this,
             method = GET + Kinetic.Type._capitalize(attr);
@@ -1087,6 +1125,27 @@
         };
     };
     Kinetic.Node.addRotationGetter = function(constructor, attr, def) {
+        var that = this,
+            method = GET + Kinetic.Type._capitalize(attr);
+            
+        // radians
+        constructor.prototype[method] = function() {
+            var val = this.attrs[attr];
+            if (val === undefined) {
+                val = def; 
+            }
+            return val;
+        };
+        // degrees
+        constructor.prototype[method + DEG] = function() {
+            var val = this.attrs[attr];
+            if (val === undefined) {
+                val = def; 
+            }
+            return Kinetic.Type._radToDeg(val);
+        };
+    };
+    Kinetic.Node.addSkewGetter = function(constructor, attr, def) {
         var that = this,
             method = GET + Kinetic.Type._capitalize(attr);
             
@@ -1245,7 +1304,35 @@
      * @methodOf Kinetic.Node.prototype
      */
 
-    Kinetic.Node.addPointGetterSetter(Kinetic.Node, 'scale', {x:1,y:1}, true);
+    Kinetic.Node.addSkewGetterSetter(Kinetic.Node, 'skew', {x:0,y:0}, true);
+
+    /**
+     * set skew in radians
+     * @name setSkew
+     * @methodOf Kinetic.Node.prototype
+     * @param {Number} theta
+     */
+
+    /**
+     * set skew in degrees
+     * @name setSkewDeg
+     * @methodOf Kinetic.Node.prototype
+     * @param {Number} deg
+     */
+
+    /**
+     * get skew in degrees
+     * @name getSkewDeg
+     * @methodOf Kinetic.Node.prototype
+     */
+
+    /**
+     * get skew in radians
+     * @name getSkew
+     * @methodOf Kinetic.Node.prototype
+     */
+
+     Kinetic.Node.addPointGetterSetter(Kinetic.Node, 'scale', {x:1,y:1}, true);
     Kinetic.Node.addPointGetterSetter(Kinetic.Node, 'offset', {x:0,y:0}, true);
 
     /**

--- a/src/util/Transform.js
+++ b/src/util/Transform.js
@@ -61,6 +61,17 @@
             this.m[3] = m22;
         },
         /**
+         * Apply skew
+         * @param {Number} radX  Angle in radians
+         * @param {Number} radY  Angle in radians
+        */
+        skew: function(radX, radY) {
+            var tx = Math.tan(radX);
+            var ty = Math.tan(radY);
+            var sm = {m: [1, ty, tx, 1, 0, 0]};
+            this.multiply(sm);
+        },
+        /**
          * Returns the translation
          * @returns {Object} 2D point(x, y)
          */


### PR DESCRIPTION
I've been trying to implement skewing on my own and realized it fit much better directly inside Node as a transformation.

Math.tan() sort of blows up at PI/2, but I didn't see any examples of bounds checking and wanted to ask about style/convention.
