### PR TITLE
Bug fix for getAttr(attr) function

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -168,7 +168,13 @@
          */
         getAttr: function(attr) {
             var method = GET + Kinetic.Type._capitalize(attr);
-            return this[method](); 
+    		if(Kinetic.Type._isFunction(this[method])) {
+				return this[method]();
+			}
+			// otherwise get directly
+			else {
+				return this.attrs[attr];
+			}
         },
         /**
          * get attrs


### PR DESCRIPTION
Now it permits to return user defined attributes which do not have a corresponding method, similar to setAttrs(config) that sets attributes as key-value whenever there is no method for the given key
