### PR TITLE
Adjustments to image filters

### DIFF
--- a/src/shapes/Image.js
+++ b/src/shapes/Image.js
@@ -138,10 +138,12 @@
                 imageData = context.getImageData(0, 0, filterCanvas.getWidth(), filterCanvas.getHeight());
                 filter.call(this, imageData);
                 context.putImageData(imageData, 0, 0);
+                return true;
             }
             catch(e) {
                 this.clearFilter();
                 Kinetic.Util.warn('Unable to apply filter. ' + e.message);
+                return false;
             }
         },
         /**


### PR DESCRIPTION
1. Unset _applyFilter flag inside applyFilter method.

This prevents applyFilter() from being called again on draw() if you have previously called it manually.
1. Report applyFilter status.

Allows user to call applyFilter manually and check whether getImageData() succeeded or failed by inspecting the return value.

This could have alternatively been done via a flag on the image object. That way you could inspect the filtering status when applyFilter was called from inside drawFunc not only when it's manually called. This just seemed like less code and effort for such a minor feature.
