### PR TITLE
Add onReset handler for Tweens

### DIFF
--- a/src/Tween.js
+++ b/src/Tween.js
@@ -67,6 +67,9 @@
         }
 
         this.reset();
+
+	// add Reset event handler after initial reset is fired
+	this.onReset = config.onReset;
     };
 
     Kinetic.Tween.tweens = {};
@@ -125,6 +128,11 @@
             tween.onFinish = function() {
                 if (that._isLastTween(tween) && that.onFinish) {
                     that.onFinish();
+                }
+            };
+            tween.onReset = function() {
+                if (that._isLastTween(tween) && that.onReset) {
+                    that.onReset();
                 }
             };
         },


### PR DESCRIPTION
If you have a Tween and call reverse() on it, there is no callback that gets called when it has finished.  The underlying Tween code has support for an onReset() handler for this case, but it is never propogated by Kinetic.Tween.  This commit adds this callback.
