### PR TITLE
Better extend function

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -262,7 +262,7 @@
             
             if(config) {
                 for(key in config) {
-                    if (key === CHILDREN) {
+                    if (key === CHILDREN || config[key] instanceof Kinetic.Node) {
                    
                     }
                     else {

--- a/src/Util.js
+++ b/src/Util.js
@@ -648,12 +648,18 @@
                 console.warn(KINETIC_WARNING + str);
             }
         },
-        extend: function(c1, c2) {
-            for(var key in c2.prototype) {
-                if(!( key in c1.prototype)) {
-                    c1.prototype[key] = c2.prototype[key];
-                }
+        extend: function(child, parent) {
+            function ctor() {
+                this.constructor = child;
             }
+            ctor.prototype = parent.prototype;
+            var old_proto = child.prototype;
+            child.prototype = new ctor();
+            for (var key in old_proto) {
+                if (old_proto.hasOwnProperty(key))
+                    child.prototype[key] = old_proto[key];
+            }
+            child.__super__ = parent.prototype;
         },
         /**
          * adds methods to a constructor prototype

--- a/tests/js/unit/nodeTests.js
+++ b/tests/js/unit/nodeTests.js
@@ -923,11 +923,14 @@ Test.Modules.NODE = {
         stage.add(layer);
 
         /*
-         * add custom attr that points to self.  The setAttrs method should
+         * add custom attr that points to circle reference.  The setAttrs method should
          * not inifinitely recurse causing a stack overflow
          */
         circle.setAttrs({
-            self: circle
+            layer: layer
+        });
+        layer.setAttrs({
+            cirlce: circle
         });
 
         /*

--- a/tests/js/unit/utilTests.js
+++ b/tests/js/unit/utilTests.js
@@ -1,0 +1,8 @@
+Test.Modules.UTIL = {
+    'test extend function': function(containerId) {
+        var circle = new Kinetic.Circle();
+        test(circle instanceof Kinetic.Circle);
+        test(circle instanceof Kinetic.Shape);
+
+    }
+};


### PR DESCRIPTION
For more usefull and expected class inheritance:

``` javascript
var circle = new Kinetic.Circle();
test(circle instanceof Kinetic.Circle);
test(circle instanceof Kinetic.Shape);
```
