### PR TITLE
Clip function now respects pixel ratio.

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -228,13 +228,14 @@
             }, true);
         },
         _clip: function(container) {
-            var context = this.getContext();
+            var context = this.getContext(),
+                pixelRatio = this.pixelRatio;
             context.save();
             this._applyAncestorTransforms(container);
             context.beginPath();
             container.getClipFunc()(this);
             context.clip();
-            context.setTransform(1, 0, 0, 1, 0, 0);
+            context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
         }
     };
 


### PR DESCRIPTION
When clipping on a screen with a pixel ratio other than 1 users were experiencing a bogus offset compared to screens with a pixel ratio of 1.

![Google Chrome](https://f.cloud.github.com/assets/437794/872306/4b08d0c6-f860-11e2-9202-bf6a4be3285d.png)
![Safari (iPad 4)](https://f.cloud.github.com/assets/437794/872307/545ac4cc-f860-11e2-8492-d2782ef17bd5.PNG)
