### PR TITLE
Fixes #543 - mouseout should fire before mouseover

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -370,12 +370,12 @@
                 shape = obj.shape;
                 if(shape) {
                     if(!go.isDragging() && obj.pixel[3] === 255 && (!this.targetShape || this.targetShape._id !== shape._id)) {
-                        shape._fireAndBubble(MOUSEOVER, evt, this.targetShape);
-                        shape._fireAndBubble(MOUSEENTER, evt, this.targetShape);
                         if(this.targetShape) {
                             this.targetShape._fireAndBubble(MOUSEOUT, evt, shape);
                             this.targetShape._fireAndBubble(MOUSELEAVE, evt, shape);
                         }
+                        shape._fireAndBubble(MOUSEOVER, evt, this.targetShape);
+                        shape._fireAndBubble(MOUSEENTER, evt, this.targetShape);
                         this.targetShape = shape;
                     }
                     else {


### PR DESCRIPTION
Fixes #543 - A mouseout event for the current node should be fired before another node fires its mouseover event.
