### PR TITLE
Text's stroke property actually strokes the text, rather than drawing on top of the fill

### DIFF
--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -125,7 +125,8 @@
                 }
 
                 this.partialText = text;
-                canvas.fillStroke(this);
+                canvas.stroke(this);
+                canvas.fill(this);
                 context.restore();
                 context.translate(0, lineHeightPx);
             }


### PR DESCRIPTION
When assigning a stroke to a Text it was filling the shape and then layering the stroke on top. The assumed nature of a stroke is to be around the text rather than overwriting it, so I've ensured that `stroke()` is called before `fill()`.

Before:
![image](https://f.cloud.github.com/assets/270706/922049/e8d6b7fc-ff16-11e2-80d8-47226fb4d720.png)

After:
![image](https://f.cloud.github.com/assets/270706/922046/d99869c0-ff16-11e2-8853-7e62a6469e1e.png)
