### PR TITLE
clone doesn't copy extension methods

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -975,10 +975,10 @@
             }
 
             //copy extensions methods
-            for (ext in this.__proto__) {
+            for (var ext in Object.getPrototypeOf(this)) {
                 //if there is a method, that is not present in the node.prototype
-                if (typeof node.__proto__[ext] != 'function') {
-                    node.__proto__[ext] = this.__proto__[ext];
+                if (typeof Object.getPrototypeOf(node)[ext] != 'function') {
+                    node[ext] = Object.getPrototypeOf(this)[ext];
                 }
             }
 


### PR DESCRIPTION
When you call clone on a 'type', that you have extended, the resulting object doesn't have the extension methods.
This should fix the issue.
