### PR TITLE
#660 Do not export default values

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -799,8 +799,12 @@
             // serialize only attributes that are not function, image, DOM, or objects with methods
             for(key in attrs) {
                 val = attrs[key];
-                if(!type._isFunction(val) && !type._isElement(val) && !(type._isObject(val) && type._hasMethods(val))) {
-                    obj.attrs[key] = val;
+                if (!type._isFunction(val) && !type._isElement(val) && !(type._isObject(val) && type._hasMethods(val))) {
+                    var getter = this[GET + Kinetic.Util._capitalize(key)];
+                    var defaultValue = null == getter ? null : getter.call({attrs: {}});
+                    if (defaultValue != val) {
+                        obj.attrs[key] = val;
+                    }
                 }
             }
 


### PR DESCRIPTION
We can check default value by invoking getter bound to blank object.
