### PR TITLE
Made callback on afterFrame be repeatable

### DIFF
--- a/src/shapes/Sprite.js
+++ b/src/shapes/Sprite.js
@@ -126,8 +126,7 @@
             this.interval = setInterval(function() {
                 var index = that.getIndex();
                 that._updateIndex();
-                if(that.afterFrameFunc && index === that.afterFrameIndex) {
-                    that.afterFrameFunc();
+                if(that.afterFrameFunc && index === that.afterFrameIndex && !that.afterFrameFunc()) {
                     delete that.afterFrameFunc;
                     delete that.afterFrameIndex;
                 }


### PR DESCRIPTION
summary: This allows people to return true from the afterFrame callback to sustain their function until the next time it occurs. 

reasoning: This would be very helpful certain situations, but would not break code in other situations. For example, I had player sprite and I wanted reloading to coincide with the animation, I could put reload() in the callback and return true if I was not down reloading. Instead of being able to do that though I had to throw an error instead to halt the flow so delete would not be called.
