### PR TITLE
Get layer fix

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1009,8 +1009,8 @@
                 x = config.x || 0,
                 y = config.y || 0,
                 canvas = new Kinetic.SceneCanvas({
-                    width: this.getWidth() || config.width || (stage ? stage.getWidth() : 0),
-                    height: this.getHeight() || config.height || (stage ? stage.getHeight() : 0),
+                    width: config.width || stage.getWidth(),
+                    height: config.height || stage.getHeight(),
                     pixelRatio: 1
                 }),
                 context = canvas.getContext();

--- a/test/unit/Node-test.js
+++ b/test/unit/Node-test.js
@@ -951,39 +951,6 @@ suite('Node', function() {
     });
 
     // ======================================================
-    test('node caching width minimal configuration', function(done) {
-        var stage = addStage();
-        var layer = new Kinetic.Layer();
-        stage.add(layer);
-
-        var rect = new Kinetic.Rect({
-            width : 50,
-            height : 50,
-            fill: 'green',
-            stroke: 'blue',
-            strokeWidth: 5,
-            draggable: true
-        });
-
-        rect.toImage({
-            callback: function(imageObj) {
-                assert.equal(Kinetic.Util._isElement(imageObj), true);
-                var cachedShape = new Kinetic.Image({
-                    image: imageObj,
-                    draggable: true,
-                    stroke: 'red',
-                    strokeWidth: 5
-                });
-
-                layer.add(cachedShape);
-                layer.draw();
-                done();
-            }
-        });
-
-        showHit(layer);
-    });
-    // ======================================================
     test('hide group', function() {
         var stage = addStage();
 


### PR DESCRIPTION
`node.getLayer()` throws exception if node not in layer.
Instead `getLayer` must return null
