### PR TITLE
DnD 'start distance' feature

### DIFF
--- a/src/DragAndDrop.js
+++ b/src/DragAndDrop.js
@@ -8,6 +8,7 @@
             y: 0
         },
         node: null,
+        distance: 1,
 
         // methods
         _drag: function(evt) {
@@ -15,6 +16,19 @@
                 node = dd.node;
 
             if(node) {
+               if(!dd.isDragging) {
+                    var pos = node.getStage().getPointerPosition();
+                    var dragDistance = node.getAttr('dragDistance') || dd.distance;
+                    var distance = Math.max(
+                        Math.abs(pos.x - dd.startPointerPos.x),
+                        Math.abs(pos.y - dd.startPointerPos.y)
+                    );
+
+                    if (distance < dragDistance) {
+                        return;
+                    }
+                }
+
                 node._setDragPosition(evt);
 
                 if(!dd.isDragging) {
@@ -83,6 +97,7 @@
             }
 
             dd.node = this;
+            dd.startPointerPos = pos;
             dd.offset.x = pos.x - ap.x;
             dd.offset.y = pos.y - ap.y;
             dd.anim.setLayers(layer || this.getLayers());


### PR DESCRIPTION
This feature can be used to prevent unwanted drags when clicking on an element.

Set global value:

``` javascript
Kinetic.DD.distance = 5;
```

Set `dragDistance` attribute:

``` javascript
var rect = new Kinetic.Rect({
  draggable: true,
  dragDistance: 5
});

circle.setAttr('dragDistance', 5);
```
