### PR TITLE
improve dragmove performance

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -362,35 +362,38 @@
         _mousemove: function(evt) {
             this._setPointerPosition(evt);
             var dd = Kinetic.DD,
+                shape;
+
+            if (!Kinetic.isDragging()) {
                 shape = this.getIntersection(this.getPointerPosition());
 
-            if(shape && shape.isListening()) {
-                if(!Kinetic.isDragging() && (!this.targetShape || this.targetShape._id !== shape._id)) {
-                    if(this.targetShape) {
-                        this.targetShape._fireAndBubble(MOUSEOUT, evt, shape);
-                        this.targetShape._fireAndBubble(MOUSELEAVE, evt, shape);
+                if(shape && shape.isListening()) {
+                    if(!this.targetShape || this.targetShape._id !== shape._id) {
+                        if(this.targetShape) {
+                            this.targetShape._fireAndBubble(MOUSEOUT, evt, shape);
+                            this.targetShape._fireAndBubble(MOUSELEAVE, evt, shape);
+                        }
+                        shape._fireAndBubble(MOUSEOVER, evt, this.targetShape);
+                        shape._fireAndBubble(MOUSEENTER, evt, this.targetShape);
+                        this.targetShape = shape;
                     }
-                    shape._fireAndBubble(MOUSEOVER, evt, this.targetShape);
-                    shape._fireAndBubble(MOUSEENTER, evt, this.targetShape);
-                    this.targetShape = shape;
+                    else {
+                        shape._fireAndBubble(MOUSEMOVE, evt);
+                    }
                 }
+                /*
+                 * if no shape was detected, clear target shape and try
+                 * to run mouseout from previous target shape
+                 */
                 else {
-                    shape._fireAndBubble(MOUSEMOVE, evt);
+                  if(this.targetShape) {
+                    this.targetShape._fireAndBubble(MOUSEOUT, evt);
+                    this.targetShape._fireAndBubble(MOUSELEAVE, evt);
+                    this.targetShape = null;
+                  }
                 }
             }
-            /*
-             * if no shape was detected, clear target shape and try
-             * to run mouseout from previous target shape
-             */
-            else {
-              if(this.targetShape && !Kinetic.isDragging()) {
-                this.targetShape._fireAndBubble(MOUSEOUT, evt);
-                this.targetShape._fireAndBubble(MOUSELEAVE, evt);
-                this.targetShape = null;
-              }
-
-            }
-
+            
             // content event
             this._fire(CONTENT_MOUSEMOVE, evt);
 


### PR DESCRIPTION
Is there any reason you want to fire MOUSEMOVE event (line 381, shape._fireAndBubble(MOUSEMOVE, evt); ) during dragging?

The this.hitCanvas.context._context.getImageData(pos.x, pos.y, 1, 1).data in _getIntersection function is very expensive during dragging. Dragging a shape feel choppy especially in a complex canvas with multiple layers. The proposed change improves the performance significantly (at least 10 times faster).  
