### PR TITLE
Shape.hasShadow cache invalidation fix

### DIFF
--- a/src/Shape.js
+++ b/src/Shape.js
@@ -43,7 +43,7 @@
             // call super constructor
             Kinetic.Node.call(this, config);
 
-            this.on('shadowColorChange.kinetic shadowBlurChange.kinetic shadowOffsetChange.kinetic shadowOpacityChange.kinetic shadowEnabledChanged.kinetic', _clearHasShadowCache);
+            this.on('shadowColorChange.kinetic shadowBlurChange.kinetic shadowOffsetChange.kinetic shadowOpacityChange.kinetic shadowEnabledChange.kinetic', _clearHasShadowCache);
         },
         hasChildren: function() {
             return false;

--- a/test/unit/Shape-test.js
+++ b/test/unit/Shape-test.js
@@ -131,6 +131,10 @@ suite('Shape', function() {
         shape.setShadowOpacity(0.5);
 
         assert.equal(shape.hasShadow(), true, 'shape should have a shadow because opacity is nonzero');
+
+        shape.setShadowEnabled(false);
+
+        assert.equal(shape.hasShadow(), false, 'shape should not have a shadow because it is not enabled');
     });
 
     // ======================================================


### PR DESCRIPTION
Typo was causing hasShadow cache not to be invalidated after using setShadowEnabled. Fixes issue #693
