### PR TITLE
Improve getIntersection performance.

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -52,7 +52,7 @@
         getIntersection: function(pos) {
             var obj, i, intersectionOffset, shape;
 
-            if(this.isVisible()) {
+            if(this.hitGraphEnabled() && this.isVisible()) {
                 for (i=0; i<INTERSECTION_OFFSETS_LEN; i++) {
                     intersectionOffset = INTERSECTION_OFFSETS[i];
                     obj = this._getIntersection({


### PR DESCRIPTION
In an application with multiple layers, if some of the layers doesn't have any shapes which are listening at all. Disable layer hit graph could improve performance.
