### PR TITLE
Fix up duplicated test names

### DIFF
--- a/test/unit/Node-test.js
+++ b/test/unit/Node-test.js
@@ -1062,31 +1062,6 @@ suite('Node', function() {
     });
 
     // ======================================================
-    test('rotation in degrees', function() {
-        var stage = addStage();
-        var layer = new Kinetic.Layer();
-        var rect = new Kinetic.Rect({
-            x: 200,
-            y: 100,
-            width: 100,
-            height: 50,
-            fill: 'green',
-            stroke: 'black',
-            strokeWidth: 4,
-            rotation: 10
-        });
-
-        assert.equal(rect.rotation(), 10);
-        rect.rotation(20);
-        assert.equal(rect.rotation(), 20);
-        rect.rotate(20);
-        assert.equal(rect.rotation(), 40);
-
-        layer.add(rect);
-        stage.add(layer);
-    });
-
-    // ======================================================
     test('get shape name', function() {
         var stage = addStage();
         var layer = new Kinetic.Layer();

--- a/test/unit/Tween-test.js
+++ b/test/unit/Tween-test.js
@@ -63,7 +63,7 @@ suite('Tween', function() {
     });
 
     // ======================================================
-    test('tween node', function() {
+    test('tween node 2', function() {
         var stage = addStage();
 
         var layer = new Kinetic.Layer();


### PR DESCRIPTION
I setup an automated build of KineticJS for my fork and collected the test results to Atlassian Bamboo. Bamboo was reporting less tests that mocha-phantom and I tracked it down to duplicate names of tests.
- Removed duplicated rotation test from Node-test (the entire test case was a duplicate).
- Renamed a test in Tween-test to give it a unique name.
