### PR TITLE
Fix animation timer drift

### DIFF
--- a/src/Animation.js
+++ b/src/Animation.js
@@ -223,8 +223,12 @@
             || FRAF;
     })();
 
+    var _lastTime = null;
     function FRAF(callback) {
-        window.setTimeout(callback, 1000 / 60);
+        var currTime = new Date().getTime();
+        var timeToCall = _lastTime ? Math.max(0, 16 - (currTime - _lastTime)) : 16;
+        window.setTimeout(callback , timeToCall);
+        _lastTime = currTime + timeToCall;
     }
 
     Kinetic.Animation.requestAnimFrame = function(callback) {


### PR DESCRIPTION
When dragging a shape, a timer used to simulate the animation frame. In some situation the timer drifted a lot which cause a noticeable lag while dragging. Fixed the timer drift by a technique introduced in following post:

http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
