### PR TITLE
When stage.toDataUrl fails, call fallback function

### DIFF
--- a/kinetic.js
+++ b/kinetic.js
@@ -8770,6 +8770,7 @@ var Kinetic = {};
          * @memberof Kinetic.Stage.prototype
          * @param {Object} config
          * @param {Function} config.callback function executed when the composite has completed
+         * @param {Function} [config.fallback] function executed when creation of the composite fails
          * @param {String} [config.mimeType] can be "image/png" or "image/jpeg".
          *  "image/png" is the default
          * @param {Number} [config.x] x position of canvas section
@@ -8792,6 +8793,7 @@ var Kinetic = {};
                     height: config.height || this.getHeight(),
                     pixelRatio: 1
                 }),
+                fallback = config.fallback || function() {},
                 _context = canvas.getContext()._context,
                 layers = this.children;
 
@@ -8803,6 +8805,10 @@ var Kinetic = {};
                 var layer = layers[n],
                     layerUrl = layer.toDataURL(),
                     imageObj = new Image();
+
+                if (layerUrl === '') {
+                    return fallback();
+                }
 
                 imageObj.onload = function() {
                     _context.drawImage(imageObj, 0, 0);


### PR DESCRIPTION
It was impossible to know if toDataUrl call fails due to SECURITY_ERR exception (same origin policy).

In my school exercise, sometimes user could add images from flickr into to the stage. I need stage saving to happen even though rendering image of the stage would fail.

I thought this addition could be useful for the project. Please feel free to use these changes in a way you wish.

Consider of changing the callbacks name `fallback` to something better.
