### PR TITLE
add() now can add multiple layers or nodes

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -83,13 +83,21 @@
             return this;
         },
         /**
-         * add node to container
+         * Add node or nodes to container.
          * @method
          * @memberof Kinetic.Container.prototype
          * @param {Node} child
+         * @param {...*} args Additional children
          * @returns {Container}
+         * @example
+         * layer.add(shape1, shape2, shape3);
          */
-        add: function(child) {
+        add: function(child, args) {
+            if (arguments.length > 1) {
+                for (var i = 0; i < arguments.length; i++) {
+                    this.add(arguments[i]);
+                }
+            }
             if (child.getParent()) {
                 child.moveTo(this);
                 return;

--- a/src/Stage.js
+++ b/src/Stage.js
@@ -313,12 +313,20 @@
             }
         },
         /**
-         * add layer to stage
+         * add layer or layers to stage
          * @method
          * @memberof Kinetic.Stage.prototype
          * @param {Kinetic.Layer} layer
+         * @param {...*} args Additional layers
+         * @example
+         * stage.add(layer1, layer2, layer3);
          */
-        add: function(layer) {
+        add: function(layer, args) {
+            if (arguments.length > 1) {
+                for (var i = 0; i < arguments.length; i++) {
+                    this.add(arguments[i]);
+                }
+            }
             Kinetic.Container.prototype.add.call(this, layer);
             layer.canvas.setSize(this.attrs.width, this.attrs.height);
             layer.hitCanvas.setSize(this.attrs.width, this.attrs.height);

--- a/test/unit/Container-test.js
+++ b/test/unit/Container-test.js
@@ -1425,13 +1425,34 @@ suite('Container', function() {
 
         assert.equal(testName.length, 1, 'group has one children with test name');
 
-
         layer.add(group);
 
-
-
-
         layer.draw();
+    });
+
+    test('add multiple nodes to container', function() {
+        var stage = addStage();
+        var layer = new Kinetic.Layer();
+        var circle1 = new Kinetic.Circle({
+            x: 0,
+            y: 0,
+            radius: 10,
+            fill: 'red'
+        });
+        var circle2 = new Kinetic.Circle({
+            x: 0,
+            y: 0,
+            radius: 10,
+            fill: 'white'
+        });
+        var circle3 = new Kinetic.Circle({
+            x: 0,
+            y: 0,
+            radius: 10,
+            fill: 'blue'
+        });
+        layer.add(circle1, circle2, circle3);
+        assert.equal(layer.getChildren().length, 3, 'layer has exactly three children');
     });
 
 });

--- a/test/unit/Stage-test.js
+++ b/test/unit/Stage-test.js
@@ -429,4 +429,13 @@ suite('Stage', function() {
         //console.log(stage.getStage());
     });
 
+    test('add multiple layers to stage', function() {
+        var stage = addStage();
+        var layer1 = new Kinetic.Layer();
+        var layer2 = new Kinetic.Layer();
+        var layer3 = new Kinetic.Layer();
+        stage.add(layer1, layer2, layer3);
+        assert.equal(stage.getLayers().length, 3, 'stage has exactly three layers');
+    });
+
 });


### PR DESCRIPTION
I thought it would be nice if `add()` could be used to add multiple layers or nodes.

```
stage.add(layer1, layer2, layer3);
layer.add(circle1, circle2, circle3);
```
