### PR TITLE
Workaround for #863, pass in correct event type to event listeners

### DIFF
--- a/src/Node.js
+++ b/src/Node.js
@@ -1508,7 +1508,7 @@
 
             if (events) {
                 for(i = 0; i < events.length; i++) {
-                    events[i].handler.call(this, evt);
+                    events[i].handler.call(this, evt, eventType);
                 }
             }
         },


### PR DESCRIPTION
The evt.type value does not always state the correct KineticJS event (see #863) and altering the property is not possible as the property is readonly (native DOM Event object). We can however pass it in as a second argument to the event listener which can be useful when listening for multiple events with one on() call and there's a need to separate them.
