### PR TITLE
Update Stage.js

### DIFF
--- a/src/Stage.js
+++ b/src/Stage.js
@@ -597,7 +597,7 @@
             // touch events
             if(evt.touches !== undefined) {
                 // currently, only handle one finger
-                if (evt.touches.length === 1) {
+                if (evt.touches.length > 0) {
 
                     touch = evt.touches[0];
 


### PR DESCRIPTION
At this time, only single finger touch is supported. However, if the first pointer event the stage receives is a multi-touch event, the value of stage.pointerPos will be left undefined. This causes:

```
`TypeError: 'undefined' is not an object (evaluating 'pos.x')`
```

in all internal the touch event handers. 
I suggest always using the location of the first finger in this case.
