### PR TITLE
Added possible fix for issue ericdrowell/KineticJS#884.

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -196,7 +196,7 @@
 
     Kinetic.HitCanvas = function(config) {
         config = config || {};
-		config.pixelRatio = 1;
+        config.pixelRatio = 1;
         var width = config.width || 0,
             height = config.height || 0;
             


### PR DESCRIPTION
This change seems to resolve the issue described in #884. I have tested out a few scenarios with various `pixelRatio` values, with different clipping values, and with the large application that I'm working on. So far, I have not seen any side-effects.

The change avoids calling `Context.reset()` (shown below) after drawing the clipping area.

```
 reset: function() {
    var pixelRatio = this.getCanvas().getPixelRatio();
    this.setTransform(1 * pixelRatio, 0, 0, 1 * pixelRatio, 0, 0);
}
```

Perhaps there is a deeper issue, where the values sent to `setTransform()` behave differently between the "display" canvas and the "hit" canvas.
