### PR TITLE
Fixed browserify support.

### DIFF
--- a/kinetic.js
+++ b/kinetic.js
@@ -562,10 +562,8 @@ var Kinetic = {};
             // Node. Does not work with strict CommonJS, but
             // only CommonJS-like enviroments that support module.exports,
             // like Node.
-
-            // We break the names to trick the browserify compiler
-            var Canvas = require('can'+'vas');
-            var jsdom = require('js'+'dom').jsdom;
+            var Canvas = require('canvas');
+            var jsdom = require('jsdom').jsdom;
             var doc = jsdom('<!DOCTYPE html><html><head></head><body></body></html>');
 
             Kinetic.document = doc;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "graphic",
     "html5"
   ],
+  "browser": {
+    "canvas": false,
+    "jsdom": false
+  },
   "bugs": {
     "url": "https://github.com/ericdrowell/KineticJS/issues"
   },


### PR DESCRIPTION
The current version in NPM breaks when trying to compile with browserify, because browserify tries to satisfy jsdom and canvas.
