### PR TITLE
Get intersection cache

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -307,6 +307,9 @@
                 cachedHitCanvas = cachedCanvas && cachedCanvas.hit;
 
             if (this.shouldDrawHit()) {
+                if (layer) {
+                    layer.imageData = null; // Clear getImageData cache
+                }
                 if (cachedHitCanvas) {
                     this._drawCachedHitCanvas(context);
                 }

--- a/src/Layer.js
+++ b/src/Layer.js
@@ -176,7 +176,6 @@
             }
 
             Kinetic.Container.prototype.drawHit.call(this, canvas, top);
-            this.imageData = null; // Clear imageData cache
             return this;
         },
         /**
@@ -195,7 +194,7 @@
         clear: function(bounds) {
             this.getContext().clear(bounds);
             this.getHitCanvas().getContext().clear(bounds);
-            this.imageData = null; // Clear imageData cache
+            this.imageData = null; // Clear getImageData cache
             return this;
         },
         // extend Node.prototype.setVisible

--- a/src/Shape.js
+++ b/src/Shape.js
@@ -203,7 +203,7 @@
                 cachedHitCanvas = cachedCanvas && cachedCanvas.hit;
 
             if(this.shouldDrawHit()) {
-                
+                layer.imageData = null; // Clear getImageData cache
                 if (cachedHitCanvas) {
                     this._drawCachedHitCanvas(context);
                 }


### PR DESCRIPTION
I have found all the calls to `getImageData` are extremely slow. This issue has been documented in many places, including [here](http://ajaxian.com/archives/canvas-image-data-optimization-tip). My application requires calls to `getIntersection` on mouse move and this was absolutely killing Firefox. Caching all hit canvas image data has resolved this issue.
