### PR TITLE
Get intersection cache

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -95,7 +95,7 @@
         _getImageData: function(x, y) {
             var width = this.hitCanvas.width || 1,
                 height = this.hitCanvas.height || 1,
-                index = Math.round( (y * width ) + x );
+                index = (Math.round(y) * width ) + Math.round(x);
 
             if (!this._hitImageData) {
                 this._hitImageData = this.hitCanvas.context.getImageData(0, 0, width, height);


### PR DESCRIPTION
I noticed that IE (11 on my machine) was reporting its mouse position as a float. This was messing up the `getImageData` calculations.
