### PR TITLE
Likely fix for "strokeScaleEnabled" issue (#530)

### DIFF
--- a/src/Context.js
+++ b/src/Context.js
@@ -580,10 +580,21 @@
         },
         _stroke: function(shape) {
             if(shape.hasStroke()) {
+                var strokeScaleEnabled = shape.getStrokeScaleEnabled();
+
+                if (!strokeScaleEnabled) {
+                    this.save();
+                    this.setTransform(1, 0, 0, 1, 0, 0);
+                }
+
                 this._applyLineCap(shape);
                 this.setAttr('lineWidth', shape.strokeWidth());
                 this.setAttr('strokeStyle', shape.colorKey);
                 shape._strokeFuncHit(this);
+
+                if (!strokeScaleEnabled) {
+                    this.restore();
+                }
             }
         }
     };


### PR DESCRIPTION
This fix for issue #530 involves copying some logic from `Kinetic.SceneContext._stroke()` to `Kinetic.HitContext._stroke()`. The `HitContext` was not updating its transforms before drawing a line with `strokeScaleEnabled == false`.

These changes resolved the immediate issues that I'm having today. I haven't tested other scenarios.
