### PR TITLE
Allow nodes to have multiple names similar to css

### DIFF
--- a/test/unit/Container-test.js
+++ b/test/unit/Container-test.js
@@ -765,6 +765,71 @@ suite('Container', function() {
     });
 
     // ======================================================
+    test('test find() selector by adding shapes with multiple names', function() {
+        var stage = addStage();
+        var layer = new Kinetic.Layer({
+            name: 'layerName',
+            id: 'layerId'
+        });
+        var group = new Kinetic.Group({
+            name: 'groupName',
+            id: 'groupId'
+        });
+        var rect = new Kinetic.Rect({
+            x: 200,
+            y: 20,
+            width: 100,
+            height: 50,
+            fill: 'red',
+            name: 'red rectangle',
+            id: 'rectId'
+        });
+        var circle = new Kinetic.Circle({
+            x: 50,
+            y: 50,
+            radius: 20,
+            fill: 'red',
+            name: 'red circle',
+            id: 'circleId'
+        });
+
+        group.add(rect);
+        group.add(circle);
+        layer.add(group);
+        stage.add(layer);
+
+        assert.equal(stage.find('.rectangle')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(stage.find('#rectId')[0].attrs.id, 'rectId', 'problem with shape id selector');
+        assert.equal(layer.find('.rectangle')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(layer.find('#rectId')[0].attrs.id, 'rectId', 'problem with shape id selector');
+        assert.equal(group.find('.rectangle')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(group.find('#rectId')[0].attrs.id, 'rectId', 'problem with shape id selector');
+
+        assert.equal(stage.find('.circle')[0].attrs.id, 'circleId', 'problem with shape name selector');
+        assert.equal(stage.find('#circleId')[0].attrs.id, 'circleId', 'problem with shape id selector');
+        assert.equal(layer.find('.circle')[0].attrs.id, 'circleId', 'problem with shape name selector');
+        assert.equal(layer.find('#circleId')[0].attrs.id, 'circleId', 'problem with shape id selector');
+        assert.equal(group.find('.circle')[0].attrs.id, 'circleId', 'problem with shape name selector');
+        assert.equal(group.find('#circleId')[0].attrs.id, 'circleId', 'problem with shape id selector');
+
+        assert.equal(stage.find('.red')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(stage.find('.red')[1].attrs.id, 'circleId', 'problem with shape name selector');
+        assert.equal(layer.find('.red')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(layer.find('.red')[1].attrs.id, 'circleId', 'problem with shape name selector');
+        assert.equal(group.find('.red')[0].attrs.id, 'rectId', 'problem with shape name selector');
+        assert.equal(group.find('.red')[1].attrs.id, 'circleId', 'problem with shape name selector');
+
+        assert.equal(stage.find('.groupName')[0].attrs.id, 'groupId', 'problem with group name selector');
+        assert.equal(stage.find('#groupId')[0].attrs.id, 'groupId', 'problem with group id selector');
+        assert.equal(layer.find('.groupName')[0].attrs.id, 'groupId', 'problem with group name selector');
+        assert.equal(layer.find('#groupId')[0].attrs.id, 'groupId', 'problem with group id selector');
+
+        assert.equal(stage.find('.layerName')[0].attrs.id, 'layerId', 'problem with layer name selector');
+        assert.equal(stage.find('#layerId')[0].attrs.id, 'layerId', 'problem with layer id selector');
+    });
+
+
+    // ======================================================
     test('test find() selector by adding shape, then group, then layer', function() {
         var stage = addStage();
         var layer = new Kinetic.Layer({

--- a/test/unit/Global-test.js
+++ b/test/unit/Global-test.js
@@ -6,26 +6,6 @@ suite('Global', function() {
     });
 
     // ======================================================
-    test('_addName', function() {
-        Kinetic._addName("node1", "single");
-        assert.equal(Kinetic.names.single[0], "node1");
-
-        Kinetic._addName("node2", "double item");
-        assert.equal(Kinetic.names.double[0], "node2");
-        assert.equal(Kinetic.names.item[0], "node2");
-
-        Kinetic._addName("node3", "  extra   spaces  ");
-        assert.equal(Kinetic.names.extra[0], "node3");
-        assert.equal(Kinetic.names.spaces[0], "node3");
-
-        Kinetic._addName("node4", "another item");
-        assert.equal(Kinetic.names.another[0], "node4");
-        assert.equal(Kinetic.names.item.length, 2);
-        assert.equal(Kinetic.names.item[0], "node2");
-        assert.equal(Kinetic.names.item[1], "node4");
-    });
-
-    // ======================================================
     test('getAngle()', function() {
         // test that default angleDeg is true
         assert.equal(Kinetic.angleDeg, true);


### PR DESCRIPTION
The name field of a shape or element currently only supports a single name, but the find selector mimics css which supports multiple class names per node. This enhancement allows the name field to also support multiple names. 

For example you could name a circle: 'red circle' and a square: 'red square', and now stage.find('.red') will return both elements, but stage.find('.square') will return just the square.
