### PR TITLE
Add findOne() convenience method on Container

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -179,6 +179,9 @@
 
             return Kinetic.Collection.toCollection(retArr);
         },
+        findOne: function(selector) {
+            return this.find(selector)[0];
+        },
         _getNodeById: function(key) {
             var node = Kinetic.ids[key];
 

--- a/test/unit/Container-test.js
+++ b/test/unit/Container-test.js
@@ -1025,6 +1025,21 @@ suite('Container', function() {
     });
 
     // ======================================================
+    test('test findOne() selector by quering existing and non-existing nodes by name', function () {
+        var stage = addStage();
+        var layer = new Kinetic.Layer();
+
+        var rect = new Kinetic.Rect({
+            name: 'rect'
+        });
+
+        layer.add(rect);
+
+        assert.equal(layer.findOne('.rect'), rect, 'findOne() on existing node must return a single node.');
+        assert.equal(layer.findOne('.doesNotExist'), undefined, 'findOne() on non-existing node must return undefined.');
+    });
+
+    // ======================================================
     test('add layer then shape', function() {
         var stage = addStage();
         var layer = new Kinetic.Layer();


### PR DESCRIPTION
There are situations when you want to find a single node by name or id. I don't see any convenient way to do this in KineticJS since `Container.find()` always returns array. `findOne` convenience method can be found from DOM API to ORM libraries, so I believe KineticJS should have one too :)

I have added a `Container.findOne()` convenience method and a simple test. it returns a node or undefined.

Optimized implementation should of course break the find() loop after first match found.
